### PR TITLE
Docs: clarify intended repository usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,28 @@ See the AWS [tutorials](./opendata/tutorials/README.md) for more detailed exampl
 - `source .venv/bin/activate`
 - `python3 download.py`
 - VS Code extensions: `Python`, `Pylance`, `ruff`
+
+### Who is this repository for?
+
+This repository serves two primary audiences:
+
+1. **Data consumers** (researchers, analysts, downstream users)
+   - Use the published datasets directly from the public S3 bucket
+   - Refer to the section *Working with data in AWS*
+
+2. **Contributors / maintainers**
+   - Use this repository to download, process, package,
+     and publish Supreme Court judgment datasets
+   - Refer to *Local development* and *Pipeline overview*
+
+## Pipeline Overview
+
+At a high level, this repository implements a batch data pipeline:
+
+1. Download raw Supreme Court judgments and metadata
+2. Normalize, clean, and validate metadata
+3. Package judgments into year-wise structured archives
+4. Publish datasets to a public S3 bucket for downstream use
+
+Most scripts are designed to be run as part of this pipeline rather than
+as standalone, user-facing commands.

--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ This repository serves two primary audiences:
 
 1. **Data consumers** (researchers, analysts, downstream users)
    - Use the published datasets directly from the public S3 bucket
-   - Refer to the section *Working with data in AWS*
+   - Refer to the section _Working with data in AWS_
 
 2. **Contributors / maintainers**
    - Use this repository to download, process, package,
      and publish Supreme Court judgment datasets
-   - Refer to *Local development* and *Pipeline overview*
+   - Refer to _Local development_ and _Pipeline overview_
 
-## Pipeline Overview
+### Pipeline Overview
 
 At a high level, this repository implements a batch data pipeline:
 
@@ -149,3 +149,29 @@ At a high level, this repository implements a batch data pipeline:
 
 Most scripts are designed to be run as part of this pipeline rather than
 as standalone, user-facing commands.
+
+---
+
+### How to think about using this repository
+
+This repository supports two different workflows, and understanding the distinction helps avoid misuse.
+
+### 1. Data consumers (most users)
+
+If your goal is analysis, research, or experimentation:
+
+- Prefer downloading data directly from the public S3 bucket
+- Use the metadata (Parquet / index files) to selectively access what you need
+- Avoid running scraping or packaging scripts locally
+
+This approach is faster, reproducible, and reduces load on upstream systems.
+
+### 2. Data maintainers or contributors
+
+If you are modifying or extending this repository:
+
+- Use the local development workflow to test changes in isolation
+- Be mindful of request volume and retry behavior when interacting with upstream sources
+- Prefer changes that improve correctness, resilience, or usability over raw throughput
+
+In short: **consume from S3 when possible; run code locally only when you are improving the pipeline itself.**


### PR DESCRIPTION
### What this PR does

Adds a short section to the README clarifying how this repository is intended to be used by different audiences.

### Why this change

While exploring the repo, it was not immediately clear whether users should:
- Run scraping scripts locally, or
- Treat this primarily as a data distribution and processing pipeline

This clarification helps set expectations early, reduce accidental misuse, and make the repo easier to approach for both data consumers and contributors.

### Scope

Documentation-only change. No changes to scraping or processing logic.